### PR TITLE
Update init.lua to handle torch.setdefaulttensortype()

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -74,7 +74,7 @@ mattorch.save = function(path,vars)
                     xlua.error('please provide a path','mattorch.save',help.save)
                  end
                  if type(vars) == 'userdata' and torch.typename(vars) == 'torch.DoubleTensor' then
-                    local tensor = torch.Tensor():resizeAs(vars):copy(vars)
+                    local tensor = torch.DoubleTensor():resizeAs(vars):copy(vars)
                     libmattorch.saveTensor(path,tensor)
 
                  elseif type(vars) == 'table' then


### PR DESCRIPTION
Handling the case of changed default tensor type (e.g. overfeat torch do the following:
   torch.setdefaulttensortype('torch.FloatTensor')
which break the code as torch.Tensor():resizeAs() would expect a FloatTensor.
